### PR TITLE
Search scorer to deprioritise retro notes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,6 +2,7 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+import os.path
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -77,6 +78,8 @@ myst_heading_anchors = 7
 myst_linkify_fuzzy_links = False
 html_last_updated_fmt = ""
 html_show_copyright = False
+
+html_search_scorer = os.path.join(os.path.dirname(__file__), "searchscorer.js")
 
 spelling_lang = "en_GB"
 spelling_filters = ["enchant.tokenize.MentionFilter"]

--- a/doc/searchscorer.js
+++ b/doc/searchscorer.js
@@ -1,0 +1,38 @@
+var Scorer = {
+    score: result => {
+      var [docName, title, anchor, descr, score, filename] = result
+	  
+	  // Deprioritize instrument details (but still include them in results)
+	  if (docName.includes("instrument_details")) {
+	    score -= 100000;
+	  }
+	  
+	  // Deprioritize retrospective-notes heavily (but still include them in results)
+	  if (docName.includes("retrospective-notes")) {
+	    score -= 1000000;
+	  }
+
+      return score
+    },
+
+    // query matches the full name of an object
+    objNameMatch: 11,
+    // or matches in the last dotted part of the object name
+    objPartialMatch: 6,
+    // Additive scores depending on the priority of the object
+    objPrio: {
+		0: 15,
+		1: 5,
+		2: -5,
+    },
+    //  Used when the priority is not in the mapping.
+    objPrioDefault: 0,
+
+    // query found in title
+    title: 15,
+    partialTitle: 7,
+
+    // query found in terms
+    term: 5,
+    partialTerm: 2,
+};


### PR DESCRIPTION
As discussed in sprint retrospective, this is a very dumb/simple deprioritizer for retrospective notes, and also the "instrument details" pages, in search results. 

All of the same results are still displayed, this is just changing order.

Longer term we could also investigate different search plugins which may allow things like `"quoted search"` etc - but this is a quick-to-implement way to make sure the top of the search results isn't polluted with retros.