### PR TITLE
signpost to replication error documentation (from wiki to ticket)

### DIFF
--- a/doc/systems/inst_control/VM-VHD-replication.md
+++ b/doc/systems/inst_control/VM-VHD-replication.md
@@ -1,0 +1,3 @@
+# VM VHD Replication
+## Replication errors
+Instructions on how to address replication errors (e.g. nagios reporting `ReplicationState>x` or `ReplicationHealth>y`) can be found [here](https://github.com/ISISComputingGroup/ControlsWork/issues/804)


### PR DESCRIPTION
Yes I would rather have them directly in the wiki as well, but right now they are in a ticket and it seems better to signpost them than do nothing