### PR TITLE
Update email template for ibex upgrade

### DIFF
--- a/doc/deployment/deploy/Updating-Instrument-Machines.md
+++ b/doc/deployment/deploy/Updating-Instrument-Machines.md
@@ -15,7 +15,7 @@ Dear All,
 
 We have recently created version **X.x.x** of IBEX and will be looking to install it to the (summer | winter) group, between **date** and **date** which includes the following instruments:
 
-The list of new features and bug fixes in this release can be found at **link to release notes**.
+The list of new features and bug fixes in this release can be found at **links to release notes since last deply to group**.
 
 To perform the release we will have to stop the instrument from taking data for a couple of hours. If there is a specific day you would like us to perform the release, you would rather not have this release for your instrument or you have any other concerns please get in contact with us ASAP. If we do not hear back from you we will assume that you are happy for us to do this any day in the above range.
 

--- a/doc/deployment/deploy/Updating-Instrument-Machines.md
+++ b/doc/deployment/deploy/Updating-Instrument-Machines.md
@@ -15,7 +15,7 @@ Dear All,
 
 We have recently created version **X.x.x** of IBEX and will be looking to install it to the (summer | winter) group, between **date** and **date** which includes the following instruments:
 
-The list of new features and bug fixes in this release can be found at **links to release notes since last deply to group**.
+The list of new features and bug fixes in this release can be found at **links to release notes since last deploy to group**.
 
 To perform the release we will have to stop the instrument from taking data for a couple of hours. If there is a specific day you would like us to perform the release, you would rather not have this release for your instrument or you have any other concerns please get in contact with us ASAP. If we do not hear back from you we will assume that you are happy for us to do this any day in the above range.
 


### PR DESCRIPTION
Given we deploy a given release to half the instruments, we need to ensure that the documentation is clear that when we email the instrument scientists,  a link is needed to all release notes since last deploy for that instrument