### PR TITLE
Better definition for genie_python... 

### DIFF
--- a/doc/Glossary.md
+++ b/doc/Glossary.md
@@ -135,7 +135,7 @@ A service that controls access between two or more networks.
 
 ## Genie Python
 
-An implementation of the [OpenGenie](http://www.opengenie.org) scripting language in Python, or at least its commands specific to instrument control.  Documentation at {external+genie_python:doc}`genie_python`.
+A python library providing programmatic interfaces to the IBEX control system. Documentation at {external+genie_python:doc}`genie_python`.
 
 ## GIT
 


### PR DESCRIPTION
`genie_python` is not an implementation of a scripting language, by any stretch of the imagination.