### PR TITLE
Remove no-longer relevant  steps

### DIFF
--- a/doc/system_components/python/Building-and-installing-uktena.md
+++ b/doc/system_components/python/Building-and-installing-uktena.md
@@ -19,12 +19,7 @@ Likewise, the genie library has no reference to uktena, and does not necessarily
 ## Setting up uktena python distribution
 
 - Check whether `C:\Instrument\Apps\Python3` already exists.
-  * If it exists and `git remote get-url origin` returns `https://github.com/ISISComputingGroup/genie_python.git`:
-    * Stop IBEX server
-    * Remove the entire `C:\Instrument\Apps\Python3` directory
-    * Proceed as if `C:\Instrument\Apps\Python3` did not exist
-  * If it exists and `git remote get-url origin` returns `https://github.com/ISISComputingGroup/uktena.git`:
-    * Perform a `git checkout master && git pull` in `C:\instrument\apps\python3`
+  * If it exists, perform a `git checkout master && git pull` in `C:\instrument\apps\python3`
   * If it does not exist, from a git-enabled command line, run `git clone https://github.com/ISISComputingGroup/uktena.git C:/Instrument/Apps/Python3` (or if using ssh authentication `git clone git@github.com:ISISComputingGroup/uktena.git`).
 - Navigate to `C:\Instrument\Apps\Python3\package_builder`
 - Be sure to have 7-Zip installed before processing with the next step.


### PR DESCRIPTION
Move of genie_python to Uktena happened a long while ago now; all devs should be on `Uktena` by now.