### PR TITLE
Update usage instructions for restore motor positions tool

### DIFF
--- a/doc/tools/archive_tools/Restore-Motor-Positions-from-Archive.md
+++ b/doc/tools/archive_tools/Restore-Motor-Positions-from-Archive.md
@@ -4,7 +4,7 @@
 Edge case: If you are applying positions obtained with this script via SECI, be careful as the user offsets may be different for each axis i.e. the difference needs to be added to the recovered position.
 ```
 
-This tool can be used to restore motor positions from the archive and put them on the current motor axis. It works by running in an epics terminal the commands:
+This tool can be used to restore motor positions from the archive and put them on the current motor axis. It works by running in an epics terminal (EPICSTerm.bat in the start menu) the commands:
 
 ```
 cd C:\Instrument\Apps\EPICS\ISIS\inst_servers\master\scripts


### PR DESCRIPTION
to make clear how to open EPICS terminal. Was going to do more of a revision of this, but couldn't use the script and so didn't make a larger PR for the documentation.