### PR TITLE
Update database backup path in troubleshooting guide

### DIFF
--- a/doc/iocs/troubleshooting/IOC-And-Device-Trouble-Shooting.md
+++ b/doc/iocs/troubleshooting/IOC-And-Device-Trouble-Shooting.md
@@ -302,7 +302,7 @@ This can be done by _importing_ the backed-up database (usually on a network dri
 Example command from a request to read chopper values on MERLIN:
 
 ```
-mysql.exe -u root -p < [insert network back-up path here]\ndxMERLIN\ibex_database_backup_2024_01_30\ibex_db_sqldump_2024_01_30.sql
+mysql.exe -u root -p < \\isis\inst$\Backups$\stage-deleted\ndxMERLIN\ibex_database_backup_2024_01_30\ibex_db_sqldump_2024_01_30.sql
 Enter password: ************
 ```
 


### PR DESCRIPTION
make path explicit. Slight increase in risk outweighed by ease of use of documentation