### PR TITLE
Modify database import command in troubleshooting doc

### DIFF
--- a/doc/iocs/troubleshooting/IOC-And-Device-Trouble-Shooting.md
+++ b/doc/iocs/troubleshooting/IOC-And-Device-Trouble-Shooting.md
@@ -299,7 +299,7 @@ Certain IOCs can be made to generate log files using the [ARACCESS component](/s
 ### Reading historical PV values from local database _after_ it has been backed up and truncated
 
 This can be done by _importing_ the backed-up database (usually on a network drive) into a local developer's copy, then reading/plotting from there.
-Example command to read vallues from the backup on yyyy-dd-mm on INSTRUMENT, to be run in an EPICS terminal (the password is in keeper "Database Root Password"):
+Example command to read values from the backup on yyyy-dd-mm on INSTRUMENT, to be run in an EPICS terminal (the password is in keeper "Database Root Password"):
 
 ```
 mysql.exe -u root -p < \\isis\inst$\Backups$\stage-deleted\ndxINSTRUMENT\ibex_db_sqldump_yyyy_mm_dd.sql

--- a/doc/iocs/troubleshooting/IOC-And-Device-Trouble-Shooting.md
+++ b/doc/iocs/troubleshooting/IOC-And-Device-Trouble-Shooting.md
@@ -299,7 +299,7 @@ Certain IOCs can be made to generate log files using the [ARACCESS component](/s
 ### Reading historical PV values from local database _after_ it has been backed up and truncated
 
 This can be done by _importing_ the backed-up database (usually on a network drive) into a local developer's copy, then reading/plotting from there.
-Example command to read vallues from the backup on yyyy-dd-mm on INSTRUMENT, to be run in an EPICSterm:
+Example command to read vallues from the backup on yyyy-dd-mm on INSTRUMENT, to be run in an EPICS terminal (the password is in keeper "Database Root Password"):
 
 ```
 mysql.exe -u root -p < \\isis\inst$\Backups$\stage-deleted\ndxINSTRUMENT\ibex_db_sqldump_yyyy_mm_dd.sql

--- a/doc/iocs/troubleshooting/IOC-And-Device-Trouble-Shooting.md
+++ b/doc/iocs/troubleshooting/IOC-And-Device-Trouble-Shooting.md
@@ -299,7 +299,7 @@ Certain IOCs can be made to generate log files using the [ARACCESS component](/s
 ### Reading historical PV values from local database _after_ it has been backed up and truncated
 
 This can be done by _importing_ the backed-up database (usually on a network drive) into a local developer's copy, then reading/plotting from there.
-Example command from a request to read chopper values on MERLIN:
+Example command to read vallues from the backup on yyyy-dd-mm on INSTRUMENT, to be run in an EPICSterm:
 
 ```
 mysql.exe -u root -p < \\isis\inst$\Backups$\stage-deleted\ndxINSTRUMENT\ibex_db_sqldump_yyyy_mm_dd.sql

--- a/doc/iocs/troubleshooting/IOC-And-Device-Trouble-Shooting.md
+++ b/doc/iocs/troubleshooting/IOC-And-Device-Trouble-Shooting.md
@@ -302,7 +302,7 @@ This can be done by _importing_ the backed-up database (usually on a network dri
 Example command from a request to read chopper values on MERLIN:
 
 ```
-mysql.exe -u root -p < \\isis\inst$\Backups$\stage-deleted\ndxMERLIN\ibex_database_backup_2024_01_30\ibex_db_sqldump_2024_01_30.sql
+mysql.exe -u root -p < \\isis\inst$\Backups$\stage-deleted\ndxINSTRUMENT\ibex_db_sqldump_yyyy_mm_dd.sql
 Enter password: ************
 ```
 


### PR DESCRIPTION
Updated example command for database import in troubleshooting guide - we no longer export to a directory for each db backup and also made directory more generic.